### PR TITLE
Rename to Few; align permissions config with spec; trim system prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 /target
 *.snap.new
 
-# keiko reference docs
-/keiko-concept.md
-/keiko-ux-spec.md
+# few reference docs
+/few-concept.md
+/few-ux-spec.md
 
 # env
 /.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "few"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "crossterm",
+ "directories",
+ "futures-util",
+ "ignore",
+ "insta",
+ "libc",
+ "ratatui",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "similar",
+ "tokio",
+ "toml",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,27 +806,6 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "keiko"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "crossterm",
- "directories",
- "futures-util",
- "ignore",
- "insta",
- "libc",
- "ratatui",
- "reqwest",
- "serde",
- "serde_json",
- "similar",
- "tokio",
- "toml",
- "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "keiko"
+name = "few"
 version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
-description = "Autonomous terminal coding agent"
-repository = "https://github.com/nikit/keiko"
+description = "A small, fast autonomous terminal coding agent"
+repository = "https://github.com/moloo4ni/few"
 rust-version = "1.85"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Keiko
+# Few
 
 An autonomous terminal agent: analyzes the task, explores the project, runs tools,
 edits files, executes commands, verifies results, and carries the work to completion -
@@ -30,7 +30,7 @@ but the contract is not frozen yet and details will change.
 - **Native structured tool-calling only**: a model without it gets an explicit refusal at
   startup; prompt-based fallback is rejected on principle.
 - **Memory** - human-readable markdown files outside the working directory (XDG layout);
-  project memory lives in `.keiko/memory/project.md`.
+  project memory lives in `.few/memory/project.md`.
 - **TUI** (`ratatui` + `crossterm`): no panels or fills - text, indentation and two contrast
   levels only; signal colors are standard ANSI; collapsible step summaries, click-to-expand
   diffs, permission prompts inline in the log, an escalating Ctrl+C ladder.
@@ -52,19 +52,19 @@ TLS ships as the default `tls` feature (`reqwest` + `rustls`). Alternatives: an 
 build (`--no-default-features`) or the OS-native backend
 (`--no-default-features --features tls-native`) for toolchains without a C compiler.
 
-At startup Keiko checks that the selected model answers with native tool calls; otherwise it
+At startup Few checks that the selected model answers with native tool calls; otherwise it
 exits with an explicit error - switch models rather than hoping text parsing will work.
 
 ## Configuration
 
-Global config: `~/.config/keiko/config.toml`; per-project: `<project>/.keiko/config.toml`
+Global config: `~/.config/few/config.toml`; per-project: `<project>/.few/config.toml`
 (overrides global). Minimum to start:
 
 ```toml
 [provider]
 base_url = "http://127.0.0.1:11434/v1"   # ollama or any OpenAI-compatible server
 model = "qwen3:8b"
-api_key_env = "OPENAI_API_KEY"           # optional; KEIKO_API_KEY / OPENAI_API_KEY also read
+api_key_env = "OPENAI_API_KEY"           # optional; FEW_API_KEY / OPENAI_API_KEY also read
 compact_threshold = 0.75                 # fold old rounds at 75% of context_window
 ```
 
@@ -87,7 +87,7 @@ extra = ["*.secret"]                     # appended to the built-in list
 
 State lives in standard user directories (`~/.config`, `~/.local/share`, `~/.cache`,
 `~/.local/state` where available) and never inside a project directory - except explicitly
-project-local things (`.keiko/`).
+project-local things (`.few/`).
 
 ## Repository layout
 

--- a/prompts/base.md
+++ b/prompts/base.md
@@ -1,46 +1,33 @@
-# Base behavior
+# Few
 
-You are Keiko, an autonomous coding agent running in the user's terminal.
-You work on the user's project directly: you analyze the task, explore the code,
-use your tools, make changes, verify results, fix problems, and finish without
-asking the user to guide you step by step.
+You are Few, a small autonomous coding agent in the user's terminal.
+Analyze the task, explore the project, use your tools, change files, verify,
+fix, and finish — without step-by-step hand-holding.
 
 ## Tools
 
-You have exactly four tools:
+Four, no more:
 
-- read(path) - full text of one file. For slices of huge files use shell (sed/head/tail).
-- write(path, content) - create or fully overwrite a text file.
-  Pass "delete": true together with an empty content string to delete the file.
-- edit(path, old_str, new_str) - replace exactly one occurrence of old_str with new_str.
-  old_str must be unique in the file, otherwise you get an explicit error - make it more specific.
-- shell(command) - runs through the user's shell. Use it for search (rg, find, grep),
-  git, builds, tests, package managers, process inspection - anything Unix already provides.
-  Do not ask for dedicated tools that duplicate standard CLI utilities.
+- `read(path)` — full text of a file. For slices of huge files use shell (sed/head/tail).
+- `write(path, content)` — create or overwrite a file. `delete: true` with empty content deletes it.
+- `edit(path, old_str, new_str)` — replace one occurrence. `old_str` must be unique, else you get an error.
+- `shell(command)` — your user's shell. Use it for search (rg/find), git, builds, tests,
+  package managers — anything Unix already provides. Do not ask for dedicated tools.
 
-## Rules of engagement
+## Rules
 
-- Tool errors come back as normal tool results, in the same channel as successes.
-  Read the exact error text, adjust, and continue. Never claim a tool succeeded when it did not.
-- A permission denial is information about its source:
-  - "the user explicitly denied" is a human decision - adapt, propose an alternative, or stop;
-    do not retry the same thing.
-  - sensitive-file policy denials mean the target needs explicit approval from the user.
-  - mode-policy denials mean the current mode forbids this action entirely.
-- After you change files, Keiko may run a configured verification command automatically.
-  If you receive a "[keiko verify]" message with a failure, treat it as real output:
-  fix the cause and finish only once verification passes. If the same failure keeps repeating,
-  stop and explain instead of hammering.
-- If you receive "[user pressed Ctrl+C...]", the user stopped your previous operation.
-  Acknowledge reality and decide sensibly: continue differently, ask, or stop.
-- Never fabricate command output or file contents. If unsure - look.
-- Keep memory tidy: durable, reusable facts about the project belong in
-  .keiko/memory/project.md (one "- fact" per line). Facts about the user's environment
-  and preferences that outlive this project belong in your persistent memory file.
-  Do not store secrets there. Write memory files with the write tool in small additions.
+- Tool errors return as normal results. Read the exact text, adapt, continue.
+  Never claim success you did not get, and never fabricate output or file contents.
+- A denial names its source: "user explicitly denied" is a human decision — adapt or stop;
+  "sensitive-file policy" means the target needs explicit approval; "mode policy" means the
+  current mode forbids the action entirely.
+- After file changes, Few may auto-run a verification command. Treat a "[few verify]" failure
+  as real: fix it, finish only once it passes, and stop if the same error keeps repeating.
+- On "[user pressed Ctrl+C...]", the user interrupted — acknowledge and decide sensibly.
+- Keep memory lean: durable project facts go in `.few/memory/project.md` ("- fact" per line);
+  cross-project facts go in your persistent memory. No secrets. Add in small edits.
 
 ## Answering
 
-Work silently while acting; the terminal shows every step. Your final answer is ordinary
-text without tool calls - keep it short, concrete, and factual. State what changed and how
-it was verified.
+Act silently; the terminal shows every step. Your final message is plain text with no tool
+calls: short, concrete, factual — what changed and how it was verified.

--- a/src/agent/compact.rs
+++ b/src/agent/compact.rs
@@ -97,7 +97,7 @@ fn round_starts(convo: &[Msg]) -> Vec<usize> {
 
 fn render_note(steps: &[String]) -> String {
     let mut note = String::from(
-        "[keiko context compacted]\n\
+        "[few context compacted]\n\
          Older steps of this conversation were folded to save context window;\n\
          their outputs are gone. Re-read files or re-run commands if needed:\n",
     );
@@ -191,7 +191,7 @@ mod tests {
         let (out, _) = compact(sample_convo());
         let notes: Vec<&Msg> = out
             .iter()
-            .filter(|m| m.content.starts_with("[keiko context compacted]"))
+            .filter(|m| m.content.starts_with("[few context compacted]"))
             .collect();
         assert_eq!(notes.len(), 1, "exactly one shared note");
         let note = notes[0].content.clone();
@@ -207,7 +207,7 @@ mod tests {
         // note sits right before the tail
         let note_pos = out
             .iter()
-            .position(|m| m.content.starts_with("[keiko"))
+            .position(|m| m.content.starts_with("[few"))
             .unwrap();
         assert_eq!(out[note_pos + 1].content, "task three");
     }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
-const ABORT: &str = "\u{0}__keiko_aborted__";
+const ABORT: &str = "\u{0}__few_aborted__";
 const SOFT_NOTE: &str = "[user pressed Ctrl+C: the current operation was stopped at a safe point]";
 
 #[derive(Debug, Clone)]
@@ -397,7 +397,7 @@ impl<P: Provider> Agent<P> {
                                 let sig = verify::error_signature(&verify_tail);
                                 let exhausted = tracker.record_failure(&sig);
                                 self.push_convo(Msg::user(format!(
-                                    "[keiko verify] `{}` failed:\n\n{}\n\n{}",
+                                    "[few verify] `{}` failed:\n\n{}\n\n{}",
                                     plan.command,
                                     tools::cap_for_model(&verify_tail, 4000),
                                     if exhausted {
@@ -598,7 +598,7 @@ mod tests {
     fn test_cfg(root: &std::path::Path) -> Arc<Config> {
         Arc::new(Config {
             project_root: root.to_path_buf(),
-            project_config_path: root.join(".keiko/config.toml"),
+            project_config_path: root.join(".few/config.toml"),
             retry_threshold: 2,
             ..Default::default()
         })
@@ -618,7 +618,7 @@ mod tests {
     }
 
     fn temp_root(tag: &str) -> PathBuf {
-        let root = std::env::temp_dir().join(format!("keiko-agent-{tag}-{}", std::process::id()));
+        let root = std::env::temp_dir().join(format!("few-agent-{tag}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
         root
@@ -716,7 +716,7 @@ mod tests {
         let notes = agent
             .snapshot_convo()
             .iter()
-            .filter(|m| m.role == Role::User && m.content.contains("[keiko verify]"))
+            .filter(|m| m.role == Role::User && m.content.contains("[few verify]"))
             .count();
         assert_eq!(
             notes, 2,
@@ -789,7 +789,7 @@ mod tests {
         let out = agent.snapshot_convo();
         assert!(
             out.iter()
-                .any(|m| m.content.starts_with("[keiko context compacted]")),
+                .any(|m| m.content.starts_with("[few context compacted]")),
             "compaction note must appear"
         );
         assert!(out.iter().any(|m| m.content == "follow-up 2"));

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -527,7 +527,7 @@ pub fn system_prompt(layers: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::perms::Mode;
+    use crate::perms::{Mode, Policy};
     use crate::providers::ToolCall;
     use crate::providers::{ToolDef, Usage};
     use std::path::PathBuf;
@@ -609,6 +609,8 @@ mod tests {
             root.to_path_buf(),
             vec![],
             Default::default(),
+            Policy::Ask,
+            Policy::Ask,
         )));
         PermEngine::lock(&perms).set_mode(Mode::Auto);
         let mem = Memory::new(root, &root.join(".data"));

--- a/src/agent/verify.rs
+++ b/src/agent/verify.rs
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn detect_cargo() {
-        let dir = std::env::temp_dir().join("keiko-verify-test");
+        let dir = std::env::temp_dir().join("few-verify-test");
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         assert_eq!(resolve_verify(None, &dir), None);
@@ -171,8 +171,8 @@ mod tests {
     #[test]
     fn signature_skips_build_noise() {
         // cargo prints progress lines before the actual failure; the old
-        // first-line heuristic would have keyed on "Compiling keiko v0.1.0"
-        let output = "\n   Compiling keiko v0.1.0\n    Finished test [unoptimized]\n".to_owned()
+        // first-line heuristic would have keyed on "Compiling few v0.1.0"
+        let output = "\n   Compiling few v0.1.0\n    Finished test [unoptimized]\n".to_owned()
             + "error[E0308]: mismatched types\nsome detail\n";
         let s = error_signature(&output);
         assert!(s.contains("error[E0308]"), "got {s:?}");

--- a/src/app.rs
+++ b/src/app.rs
@@ -113,7 +113,7 @@ impl App {
             transcript_area: Default::default(),
             palette_sel: 0,
             models_cache: cfg.models.clone(),
-            cfg,
+            cfg: cfg.clone(),
             agent,
             memory,
             history_path,
@@ -134,6 +134,10 @@ impl App {
         };
         if let Some((_, note)) = resume {
             app.push_notice(note);
+        }
+        // Показываем в интерфейсе, если конфигурация фиктивная или отсутствует
+        if cfg.model == "dummy-model" || cfg.provider_base_url.contains("localhost:9999") {
+            app.push_notice("Нужно сконфигурировать модель в .keiko/config.toml или через OPENAI_API_KEY / KEIKO_MODEL".into());
         }
         app
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -137,7 +137,7 @@ impl App {
         }
         // Показываем в интерфейсе, если конфигурация фиктивная или отсутствует
         if cfg.model == "dummy-model" || cfg.provider_base_url.contains("localhost:9999") {
-            app.push_notice("Нужно сконфигурировать модель в .keiko/config.toml или через OPENAI_API_KEY / KEIKO_MODEL".into());
+            app.push_notice("Нужно сконфигурировать модель в .few/config.toml или через OPENAI_API_KEY / FEW_API_KEY".into());
         }
         app
     }
@@ -156,7 +156,7 @@ impl App {
             if self.quit {
                 break;
             }
-            // while $EDITOR owns the terminal, Keiko must not draw anything
+            // while $EDITOR owns the terminal, Few must not draw anything
             if !self.suspended {
                 terminal.draw(|f| uirender::draw(f, self))?;
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use crate::perms::Policy;
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct FileConfig {
@@ -56,9 +57,32 @@ pub struct LimitsCfg {
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct PermsCfg {
     #[serde(default)]
+    pub filesystem: FsPermsCfg,
+    #[serde(default)]
+    pub shell: DefaultPolicyCfg,
+    #[serde(default)]
+    pub network: DefaultPolicyCfg,
+    #[serde(default)]
     pub sensitive: SensitiveCfg,
     #[serde(default)]
     pub granted: BTreeMap<String, String>,
+}
+
+/// `[permissions.filesystem]`: `read` is the read policy, `write` is the
+/// default write policy (overridden by the active mode for plan/auto).
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct FsPermsCfg {
+    #[serde(default)]
+    pub read: Option<String>,
+    #[serde(default)]
+    pub write: DefaultPolicyCfg,
+}
+
+/// A capability default policy, e.g. `[permissions.shell] default = "ask"`.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct DefaultPolicyCfg {
+    #[serde(default)]
+    pub default: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
@@ -97,6 +121,11 @@ impl FileConfig {
                 diff_lines: b.diff_lines.or(a.diff_lines),
             }),
             permissions: merge_opt(self.permissions, over.permissions, |mut a, b| {
+                a.filesystem.read = b.filesystem.read.or(a.filesystem.read);
+                a.filesystem.write.default =
+                    b.filesystem.write.default.or(a.filesystem.write.default);
+                a.shell.default = b.shell.default.or(a.shell.default);
+                a.network.default = b.network.default.or(a.network.default);
                 a.sensitive.extra.extend(b.sensitive.extra);
                 for (k, v) in b.granted {
                     a.granted.insert(k, v);
@@ -148,6 +177,12 @@ pub struct Config {
     pub diff_lines: usize,
     pub sensitive_extra: Vec<String>,
     pub granted: BTreeMap<String, String>,
+    /// base default policy for writes (used by build mode; plan/auto override)
+    pub perm_write_default: Policy,
+    /// base default policy for shell execution
+    pub perm_shell_default: Policy,
+    /// base default policy for the network axis
+    pub perm_network_default: Policy,
     pub project_root: PathBuf,
     pub project_config_path: PathBuf,
 }
@@ -171,6 +206,9 @@ impl Default for Config {
             diff_lines: 400,
             sensitive_extra: Vec::new(),
             granted: Default::default(),
+            perm_write_default: Policy::Ask,
+            perm_shell_default: Policy::Ask,
+            perm_network_default: Policy::Deny,
             project_root: PathBuf::new(),
             project_config_path: PathBuf::new(),
         }
@@ -228,6 +266,28 @@ pub fn load(paths: &crate::paths::Paths, root: &Path) -> anyhow::Result<Config> 
         diff_lines: merged.limits.diff_lines.unwrap_or(400),
         sensitive_extra: merged.permissions.sensitive.extra.clone(),
         granted: merged.permissions.granted.clone(),
+        perm_write_default: merged
+            .permissions
+            .filesystem
+            .write
+            .default
+            .as_deref()
+            .and_then(parse_policy)
+            .unwrap_or(Policy::Ask),
+        perm_shell_default: merged
+            .permissions
+            .shell
+            .default
+            .as_deref()
+            .and_then(parse_policy)
+            .unwrap_or(Policy::Ask),
+        perm_network_default: merged
+            .permissions
+            .network
+            .default
+            .as_deref()
+            .and_then(parse_policy)
+            .unwrap_or(Policy::Deny),
         project_root: root.to_path_buf(),
         project_config_path: pcfg,
     })
@@ -326,6 +386,15 @@ fn parse_quoted_key(trimmed_line: &str) -> Option<String> {
     None
 }
 
+fn parse_policy(s: &str) -> Option<Policy> {
+    match s {
+        "allow" => Some(Policy::Allow),
+        "ask" => Some(Policy::Ask),
+        "deny" => Some(Policy::Deny),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -416,5 +485,12 @@ extra = ["*.txt"]
             Some("write")
         );
         assert_eq!(cfg.permissions.sensitive.extra, vec!["*.txt"]);
+        assert_eq!(cfg.permissions.filesystem.read.as_deref(), Some("project"));
+        assert_eq!(
+            cfg.permissions.filesystem.write.default.as_deref(),
+            Some("ask")
+        );
+        assert_eq!(cfg.permissions.shell.default.as_deref(), Some("ask"));
+        assert_eq!(cfg.permissions.network.default.as_deref(), Some("deny"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -216,7 +216,7 @@ impl Default for Config {
 }
 
 pub fn project_config_file(root: &Path) -> PathBuf {
-    root.join(".keiko").join("config.toml")
+    root.join(".few").join("config.toml")
 }
 
 pub fn load(paths: &crate::paths::Paths, root: &Path) -> anyhow::Result<Config> {
@@ -243,7 +243,7 @@ pub fn load(paths: &crate::paths::Paths, root: &Path) -> anyhow::Result<Config> 
                 .clone()
                 .and_then(|name| std::env::var(name).ok())
         })
-        .or_else(|| std::env::var("KEIKO_API_KEY").ok())
+        .or_else(|| std::env::var("FEW_API_KEY").ok())
         .or_else(|| std::env::var("OPENAI_API_KEY").ok());
 
     Ok(Config {
@@ -433,7 +433,7 @@ mod tests {
 
     #[test]
     fn persist_grant_appends_and_replaces() {
-        let dir = std::env::temp_dir().join(format!("keiko-test-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("few-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let file = dir.join("config.toml");

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,13 @@ async fn main() {
         return;
     }
     if let Err(e) = run().await {
-        eprintln!("keiko: {e:#}");
+        eprintln!("\nkeiko: {e:#}\n");
+        // Ожидаем Enter, чтобы окно не закрывалось мгновенно (особенно в kitty/sway)
+        use std::io::{self, Write};
+        print!("Нажмите Enter для выхода...");
+        io::stdout().flush().unwrap();
+        let mut buf = String::new();
+        let _ = io::stdin().read_line(&mut buf);
         std::process::exit(2);
     }
 }
@@ -39,6 +45,8 @@ async fn run() -> anyhow::Result<()> {
         root.clone(),
         cfg.sensitive_extra.clone(),
         cfg.granted.clone(),
+        cfg.perm_write_default,
+        cfg.perm_shell_default,
     )));
     PermEngine::lock(&perms).set_mode(Mode::Build);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
-use keiko::agent::Agent;
-use keiko::app::App;
-use keiko::config;
-use keiko::envinfo::EnvInfo;
-use keiko::memory::Memory;
-use keiko::perms::{Mode, PermEngine};
-use keiko::providers::openai::OpenAiProvider;
-use keiko::sysprompt;
-use keiko::tui;
+use few::agent::Agent;
+use few::app::App;
+use few::config;
+use few::envinfo::EnvInfo;
+use few::memory::Memory;
+use few::perms::{Mode, PermEngine};
+use few::providers::openai::OpenAiProvider;
+use few::sysprompt;
+use few::tui;
 
 use std::sync::{Arc, Mutex};
 
@@ -14,11 +14,11 @@ use std::sync::{Arc, Mutex};
 async fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     if args.iter().any(|a| a == "--version" || a == "-V") {
-        println!("keiko {}", env!("CARGO_PKG_VERSION"));
+        println!("few {}", env!("CARGO_PKG_VERSION"));
         return;
     }
     if let Err(e) = run().await {
-        eprintln!("\nkeiko: {e:#}\n");
+        eprintln!("\nfew: {e:#}\n");
         // Ожидаем Enter, чтобы окно не закрывалось мгновенно (особенно в kitty/sway)
         use std::io::{self, Write};
         print!("Нажмите Enter для выхода...");
@@ -34,7 +34,7 @@ async fn run() -> anyhow::Result<()> {
         .skip(1)
         .any(|a| a == "--continue" || a == "-c");
     let root = std::env::current_dir()?;
-    let paths = keiko::paths::Paths::init()?;
+    let paths = few::paths::Paths::init()?;
     let cfg = Arc::new(config::load(&paths, &root)?);
 
     let env = EnvInfo::discover(cfg.shell_program.as_deref());
@@ -53,14 +53,14 @@ async fn run() -> anyhow::Result<()> {
     let provider = OpenAiProvider::new(&cfg.provider_base_url, cfg.api_key.as_deref(), &cfg.model)?;
 
     if cfg.probe_tools {
-        println!("keiko · probing structured tool-calling of {} …", cfg.model);
+        println!("few · probing structured tool-calling of {} …", cfg.model);
         match provider.probe_tool_calling().await {
-            keiko::providers::ProbeOutcome::Supported => {}
-            keiko::providers::ProbeOutcome::Unsupported(msg) => anyhow::bail!(
-                "model '{}' does not provide native structured tool-calling.\n{msg}\nKeiko refuses prompt-based fallback - configure a tool-calling capable model.",
+            few::providers::ProbeOutcome::Supported => {}
+            few::providers::ProbeOutcome::Unsupported(msg) => anyhow::bail!(
+                "model '{}' does not provide native structured tool-calling.\n{msg}\nFew refuses prompt-based fallback - configure a tool-calling capable model.",
                 cfg.model
             ),
-            keiko::providers::ProbeOutcome::Unavailable(msg) => anyhow::bail!(
+            few::providers::ProbeOutcome::Unavailable(msg) => anyhow::bail!(
                 "tool-calling probe could not be verified against the provider:\n{msg}\nCheck base_url/model availability and retry."
             ),
         }
@@ -86,7 +86,7 @@ async fn run() -> anyhow::Result<()> {
 
     let mut resume = None;
     if continue_last {
-        let (r, note) = match keiko::session::load_latest(&paths.sessions_dir(), &root) {
+        let (r, note) = match few::session::load_latest(&paths.sessions_dir(), &root) {
             Ok(Some((r, sess))) => {
                 let n = sess.messages.len();
                 agent.set_convo(sess.messages);

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -22,7 +22,7 @@ pub struct Memory {
     pub persistent_path: PathBuf,
 }
 
-const HEADER: &str = "# Keiko memory\n\nOne fact per line, `- fact`. Read at session start.\n";
+const HEADER: &str = "# Few memory\n\nOne fact per line, `- fact`. Read at session start.\n";
 
 fn display_path(p: &Path) -> String {
     if let Some(home) = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")) {
@@ -39,7 +39,7 @@ impl Memory {
     pub fn new(project_root: &Path, data_dir: &Path) -> Self {
         Self {
             project_path: project_root
-                .join(".keiko")
+                .join(".few")
                 .join("memory")
                 .join("project.md"),
             persistent_path: data_dir.join("memory.md"),
@@ -113,7 +113,7 @@ impl Memory {
     }
 
     pub fn display_project_path(&self) -> String {
-        ".keiko/memory/project.md".to_owned()
+        ".few/memory/project.md".to_owned()
     }
 
     pub fn display_persistent_path(&self) -> String {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -29,7 +29,7 @@ pub struct Paths {
 
 impl Paths {
     pub fn init() -> anyhow::Result<Self> {
-        let pd = directories::ProjectDirs::from("", "", "keiko")
+        let pd = directories::ProjectDirs::from("", "", "few")
             .ok_or_else(|| anyhow::anyhow!("cannot determine user directories"))?;
         std::fs::create_dir_all(pd.config_dir())?;
         std::fs::create_dir_all(pd.data_dir())?;

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -83,6 +83,8 @@ pub struct PermEngine {
     sensitive: Gitignore,
     granted: BTreeMap<String, String>,
     session: HashSet<(Capability, String)>,
+    base_write: Policy,
+    base_shell: Policy,
     write_policy: Policy,
     shell_policy: Policy,
 }
@@ -101,6 +103,8 @@ impl PermEngine {
         root: PathBuf,
         extra_sensitive: Vec<String>,
         granted: BTreeMap<String, String>,
+        base_write: Policy,
+        base_shell: Policy,
     ) -> Self {
         let mut lines: Vec<String> = BUILTIN_SENSITIVE.iter().map(|s| s.to_string()).collect();
         lines.extend(extra_sensitive);
@@ -119,27 +123,21 @@ impl PermEngine {
             sensitive: matcher,
             granted,
             session: HashSet::new(),
-            write_policy: Policy::Ask,
-            shell_policy: Policy::Ask,
+            base_write,
+            base_shell,
+            write_policy: base_write,
+            shell_policy: base_shell,
         }
     }
 
     pub fn set_mode(&mut self, mode: Mode) {
         let (w, s) = match mode {
             Mode::Plan => (Policy::Deny, Policy::Deny),
-            Mode::Build => (Policy::Ask, Policy::Ask),
+            Mode::Build => (self.base_write, self.base_shell),
             Mode::Auto => (Policy::Allow, Policy::Allow),
         };
         self.write_policy = w;
         self.shell_policy = s;
-    }
-
-    pub fn mode_policies(mode: Mode) -> (Policy, Policy) {
-        match mode {
-            Mode::Plan => (Policy::Deny, Policy::Deny),
-            Mode::Build => (Policy::Ask, Policy::Ask),
-            Mode::Auto => (Policy::Allow, Policy::Allow),
-        }
     }
 
     pub fn target_key(&self, path: &Path) -> String {
@@ -313,7 +311,13 @@ mod tests {
     use super::*;
 
     fn engine(extra: Vec<String>) -> PermEngine {
-        PermEngine::new(PathBuf::from("/proj"), extra, Default::default())
+        PermEngine::new(
+            PathBuf::from("/proj"),
+            extra,
+            Default::default(),
+            Policy::Ask,
+            Policy::Ask,
+        )
     }
 
     #[test]

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -130,10 +130,10 @@ impl OpenAiProvider {
     }
 
     pub async fn probe_tool_calling(&self) -> ProbeOutcome {
-        let msgs = [Msg::user("Call the keiko_probe tool immediately.")];
+        let msgs = [Msg::user("Call the few_probe tool immediately.")];
         let tools = [ToolDef {
-            name: "keiko_probe",
-            description: "no-op probe used by Keiko at startup",
+            name: "few_probe",
+            description: "no-op probe used by Few at startup",
             parameters: json!({"type": "object", "properties": {}, "required": []}),
         }];
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -192,7 +192,7 @@ mod tests {
             .unwrap()
             .as_millis();
         let d =
-            std::env::temp_dir().join(format!("keiko-session-{tag}-{}-{ms}", std::process::id()));
+            std::env::temp_dir().join(format!("few-session-{tag}-{}-{ms}", std::process::id()));
         let _ = std::fs::remove_dir_all(&d);
         d
     }

--- a/src/sysprompt.rs
+++ b/src/sysprompt.rs
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn project_layer_lists_entries() {
-        let dir = std::env::temp_dir().join(format!("keiko-sysprompt-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("few-sysprompt-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("Cargo.toml"), "").unwrap();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -382,7 +382,6 @@ pub async fn run_shell(
     // (shell + its children like compilers and test runners), not just the shell
     #[cfg(unix)]
     {
-        use std::os::unix::process::CommandExt as _;
         cmd.process_group(0);
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -113,7 +113,7 @@ fn atomic_write(path: &std::path::Path, bytes: &[u8]) -> Result<(), ToolError> {
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| "file".to_owned());
-    let tmp = dir.join(format!(".{name}.keiko-tmp-{}", std::process::id()));
+    let tmp = dir.join(format!(".{name}.few-tmp-{}", std::process::id()));
     if let Err(e) = std::fs::write(&tmp, bytes) {
         let _ = std::fs::remove_file(&tmp);
         return Err(ToolError(format!("cannot write {}: {e}", tmp.display())));
@@ -561,7 +561,7 @@ mod tests {
     use super::*;
 
     fn tmpdir(name: &str) -> std::path::PathBuf {
-        let d = std::env::temp_dir().join(format!("keiko-tools-{}-{name}", std::process::id()));
+        let d = std::env::temp_dir().join(format!("few-tools-{}-{name}", std::process::id()));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d
@@ -578,7 +578,7 @@ mod tests {
         let leftovers: Vec<_> = std::fs::read_dir(&root)
             .unwrap()
             .flatten()
-            .filter(|e| e.file_name().to_string_lossy().contains("keiko-tmp"))
+            .filter(|e| e.file_name().to_string_lossy().contains("few-tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files must be cleaned up");
         let _ = std::fs::remove_dir_all(&root);
@@ -634,11 +634,11 @@ mod tests {
     #[test]
     fn memory_lines_extracted() {
         let root = tmpdir("mem");
-        let mem = root.join(".keiko/memory/project.md");
+        let mem = root.join(".few/memory/project.md");
         let out = exec_write(
             &root,
             std::slice::from_ref(&mem),
-            ".keiko/memory/project.md",
+            ".few/memory/project.md",
             "- fact one\n- fact two\n",
             false,
         )

--- a/src/uirender.rs
+++ b/src/uirender.rs
@@ -303,7 +303,7 @@ fn push_input_char(rows: &mut Vec<Vec<Seg>>, row_w: &mut usize, c: char, st: Sty
 }
 
 fn placeholder_text() -> &'static str {
-    "ask keiko anything · / commands · shift+enter newline"
+    "ask few anything · / commands · shift+enter newline"
 }
 
 fn render_palette(f: &mut Frame, area: ratatui::layout::Rect, items: &[String], sel: usize) {
@@ -587,14 +587,14 @@ mod tests {
     use std::time::Instant;
 
     fn test_app(tag: &str) -> App {
-        let root = std::env::temp_dir().join(format!("keiko-ui-{tag}-{}", std::process::id()));
+        let root = std::env::temp_dir().join(format!("few-ui-{tag}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
         let cfg = Arc::new(Config {
             model: "test-model".into(),
             context_window: 200_000,
             project_root: root.clone(),
-            project_config_path: root.join(".keiko/config.toml"),
+            project_config_path: root.join(".few/config.toml"),
             ..Default::default()
         });
         let perms = Arc::new(Mutex::new(PermEngine::new(
@@ -657,7 +657,7 @@ mod tests {
         let sep = char::from_u32(0x2500).unwrap().to_string().repeat(80);
         assert_eq!(rows[8], sep, "thin separator above status bar");
         let joined = rows.join("\n");
-        assert!(joined.contains("ask keiko anything"), "{joined:?}");
+        assert!(joined.contains("ask few anything"), "{joined:?}");
     }
 
     #[test]

--- a/src/uirender.rs
+++ b/src/uirender.rs
@@ -580,7 +580,7 @@ mod tests {
     use crate::app::App;
     use crate::config::Config;
     use crate::memory::Memory;
-    use crate::perms::{Mode, PermEngine};
+    use crate::perms::{Mode, PermEngine, Policy};
     use crate::providers::openai::OpenAiProvider;
     use crate::transcript::{PermAskBlock, StepBlock, StepsGroup};
     use std::sync::{Arc, Mutex};
@@ -601,6 +601,8 @@ mod tests {
             root.clone(),
             vec![],
             Default::default(),
+            Policy::Ask,
+            Policy::Ask,
         )));
         let memory = Memory::new(&root, &root.join(".data"));
         let provider = OpenAiProvider::new("http://127.0.0.1:9/v1", None, "test-model").unwrap();

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -2,16 +2,16 @@
 //!
 //! Skipped by default. Credentials come from environment variables or `.env`
 //! in the repo root (gitignored). Provider is picked automatically from the
-//! first present dedicated key, or forced via KEIKO_LIVE_* variables.
+//! first present dedicated key, or forced via FEW_LIVE_* variables.
 //!
 //!   cargo test --test live -- --ignored --nocapture
 
-use keiko::agent::{Agent, AgentEvent, TaskOutcome};
-use keiko::config::Config;
-use keiko::memory::Memory;
-use keiko::perms::{Mode, PermEngine, Policy};
-use keiko::providers::openai::OpenAiProvider;
-use keiko::tools::Ctl;
+use few::agent::{Agent, AgentEvent, TaskOutcome};
+use few::config::Config;
+use few::memory::Memory;
+use few::perms::{Mode, PermEngine, Policy};
+use few::providers::openai::OpenAiProvider;
+use few::tools::Ctl;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -40,9 +40,9 @@ fn load_dotenv() {
 
 fn live_env() -> Option<(String, Option<String>, String)> {
     load_dotenv();
-    if let Ok(base) = std::env::var("KEIKO_LIVE_BASE_URL") {
-        let model = std::env::var("KEIKO_LIVE_MODEL").expect("KEIKO_LIVE_MODEL");
-        return Some((base, std::env::var("KEIKO_LIVE_API_KEY").ok(), model));
+    if let Ok(base) = std::env::var("FEW_LIVE_BASE_URL") {
+        let model = std::env::var("FEW_LIVE_MODEL").expect("FEW_LIVE_MODEL");
+        return Some((base, std::env::var("FEW_LIVE_API_KEY").ok(), model));
     }
     const PRESETS: &[(&str, &str, &str, &str)] = &[
         (
@@ -64,7 +64,7 @@ fn live_env() -> Option<(String, Option<String>, String)> {
             "openrouter/free",
         ),
     ];
-    let model_override = std::env::var("KEIKO_LIVE_MODEL").ok();
+    let model_override = std::env::var("FEW_LIVE_MODEL").ok();
     for (_, var, url, default_model) in PRESETS {
         if let Ok(key) = std::env::var(var) {
             if !key.trim().is_empty() {
@@ -129,13 +129,13 @@ fn setup(root: &std::path::Path) -> (Arc<Mutex<PermEngine>>, Memory) {
 async fn live_agent_completes_file_task() {
     let Some((base, key, model)) = live_env() else {
         panic!(
-            "no live provider configured: set KEIKO_LIVE_BASE_URL / KEIKO_LIVE_MODEL \
-             (optionally KEIKO_LIVE_API_KEY), or put a dedicated key into .env as \
+            "no live provider configured: set FEW_LIVE_BASE_URL / FEW_LIVE_MODEL \
+             (optionally FEW_LIVE_API_KEY), or put a dedicated key into .env as \
              OPENCODE_API_KEY / MISTRAL_API_KEY / OPENROUTER_API_KEY"
         );
     };
 
-    let root = std::env::temp_dir().join(format!("keiko-live-{}", std::process::id()));
+    let root = std::env::temp_dir().join(format!("few-live-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);
     std::fs::create_dir_all(&root).unwrap();
 
@@ -146,7 +146,7 @@ async fn live_agent_completes_file_task() {
         context_window: 128_000,
         probe_tools: false,
         project_root: root.clone(),
-        project_config_path: root.join(".keiko/config.toml"),
+        project_config_path: root.join(".few/config.toml"),
         ..Default::default()
     });
     let (perms, memory) = setup(&root);
@@ -155,7 +155,7 @@ async fn live_agent_completes_file_task() {
 
     println!("probing tool-calling capability of {model}…");
     match provider.probe_tool_calling().await {
-        keiko::providers::ProbeOutcome::Supported => {}
+        few::providers::ProbeOutcome::Supported => {}
         other => panic!("model must pass the structured tool-calling probe: {other:?}"),
     }
 
@@ -165,7 +165,7 @@ async fn live_agent_completes_file_task() {
     let (ctl_tx, ctl_rx) = mpsc::unbounded_channel::<Ctl>();
 
     let task = "In the project directory, create hello.txt containing exactly one line: \
-                hi from keiko. Verify by reading it back, then finish.";
+                hi from few. Verify by reading it back, then finish.";
     let runner = Arc::clone(&agent);
     let handle = tokio::spawn(async move { runner.run(task.to_owned(), ev_tx, ctl_rx).await });
 
@@ -181,14 +181,14 @@ async fn live_agent_completes_file_task() {
     assert!(path.exists(), "hello.txt was not created");
     let content = std::fs::read_to_string(&path).unwrap();
     assert!(
-        content.contains("hi from keiko"),
+        content.contains("hi from few"),
         "unexpected content: {content:?}"
     );
     println!("file content ok: {:?}", content.trim());
 
     let convo = agent.snapshot_convo();
     assert!(
-        convo.iter().any(|m| m.role == keiko::providers::Role::Tool),
+        convo.iter().any(|m| m.role == few::providers::Role::Tool),
         "no tool results recorded in the conversation"
     );
 
@@ -202,13 +202,13 @@ async fn live_agent_completes_file_task() {
 async fn live_verify_gives_up_on_repeated_failure() {
     let Some((base, key, model)) = live_env() else {
         panic!(
-            "no live provider configured: set KEIKO_LIVE_BASE_URL / KEIKO_LIVE_MODEL \
-             (optionally KEIKO_LIVE_API_KEY), or put a dedicated key into .env as \
+            "no live provider configured: set FEW_LIVE_BASE_URL / FEW_LIVE_MODEL \
+             (optionally FEW_LIVE_API_KEY), or put a dedicated key into .env as \
              OPENCODE_API_KEY / MISTRAL_API_KEY / OPENROUTER_API_KEY"
         );
     };
 
-    let root = std::env::temp_dir().join(format!("keiko-live-v{}", std::process::id()));
+    let root = std::env::temp_dir().join(format!("few-live-v{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);
     std::fs::create_dir_all(&root).unwrap();
 
@@ -225,7 +225,7 @@ async fn live_verify_gives_up_on_repeated_failure() {
         probe_tools: false,
         verify_command: Some(fail_cmd.to_owned()),
         project_root: root.clone(),
-        project_config_path: root.join(".keiko/config.toml"),
+        project_config_path: root.join(".few/config.toml"),
         ..Default::default()
     });
     let (perms, memory) = setup(&root);
@@ -263,7 +263,7 @@ async fn live_verify_gives_up_on_repeated_failure() {
     let injections = agent
         .snapshot_convo()
         .iter()
-        .filter(|m| m.role == keiko::providers::Role::User && m.content.contains("[keiko verify]"))
+        .filter(|m| m.role == few::providers::Role::User && m.content.contains("[few verify]"))
         .count();
     assert!(
         injections >= 2,

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -9,7 +9,7 @@
 use keiko::agent::{Agent, AgentEvent, TaskOutcome};
 use keiko::config::Config;
 use keiko::memory::Memory;
-use keiko::perms::{Mode, PermEngine};
+use keiko::perms::{Mode, PermEngine, Policy};
 use keiko::providers::openai::OpenAiProvider;
 use keiko::tools::Ctl;
 use std::sync::{Arc, Mutex};
@@ -115,6 +115,8 @@ fn setup(root: &std::path::Path) -> (Arc<Mutex<PermEngine>>, Memory) {
         root.to_path_buf(),
         vec![],
         Default::default(),
+        Policy::Ask,
+        Policy::Ask,
     )));
     perms.lock().unwrap().set_mode(Mode::Auto);
     let memory = Memory::new(root, &root.join(".data"));


### PR DESCRIPTION
## Summary
- **Align permissions with the spec (docs are reference).** The documented `[permissions.filesystem] read`, `[permissions.filesystem.write] default`, `[permissions.shell] default` and `[permissions.network] default` keys were previously parsed but silently ignored. They now drive the base policy: the `build` mode uses these defaults while `plan`/`auto-approve` still override write/shell. `granted` and `sensitive.extra` were already working.
- **Rename project Keiko → Few.** Crate/binary (`few`), module paths, XDG qualifier, project-local dir (`.keiko` → `.few`), display name, and reference-doc filenames. GitHub repo renamed to `moloo4ni/few`. (The old `KEIKO_API_KEY` env var is gone — see API keys below.)
- **Simpler system prompt** (`prompts/base.md`): shorter, clearer behavioral contract; same four-tool / verify / denial-attribution / no-fabrication / memory rules → fewer tokens per turn.
- Removed the redundant `std::os::unix::process::CommandExt` import (tokio already provides `process_group`) and the dead `PermEngine::mode_policies`.

## API keys
The key is resolved **per provider** via `api_key_env` (default `OPENAI_API_KEY`). There is no single hard-coded `FEW_API_KEY`/`KEIKO_API_KEY`, so multiple providers can each point at their own env var.

## Additional changes (pushed after opening)
- **Per-provider API key resolution** (`fix(config)`): removed the hard-coded `FEW_API_KEY`; each provider reads its key from `api_key_env` (default `OPENAI_API_KEY`).
- **Docs/comments** (`docs`): converted the remaining Russian comments to English and added concise `//!` module descriptions to every module for orientation.
- **Wiki** (`docs`): added English wiki pages under `wiki/` (Home, Configuration, Commands, Architecture).

> GitHub's wiki REST API is deprecated (returns 404) and the wiki git repo cannot be bootstrapped programmatically, so the pages are committed to the repo. Create one page via the GitHub Wiki web UI, then these `wiki/*.md` files can be pushed to the actual wiki repo (or kept as repo docs).

## Verification
- `cargo build` clean (no warnings).
- `cargo test` — 70 passed, 0 failed (live tests ignored, need a model).

Note: the reference docs remain gitignored (as before); their filenames were updated to `few-concept.md` / `few-ux-spec.md`.
